### PR TITLE
Create INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,17 @@
+Installation Instructions
+=========================
+
+Requirements
+------------
+
+* automake 1.14, or later
+* autoconf
+* libtool
+
+Installing
+----------
+
+1. `autoreconf -fiv`
+2. `./configure`
+3. `make`
+4. `make install`


### PR DESCRIPTION
`autoreconf -fiv` fails with automake versions older than 1.14, so create build instructions and specify the required minimum version of automake.